### PR TITLE
Add IAM Permissions section to README and README_CN

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,23 +50,36 @@ As the project is still in rapid itelating, we would like to suggest developers 
 5. run `yarn app:dev` to start a desktop app in developer mode.    or:   run `yarn dev` to start a local server and then access the app with browser.
 6. Optional, if you want to run it as an app, run `yarn app:build` to build it, and the find the target file (we believe you can, :-)
 
-### Least-privilege IAM Permission
-```
-{
+#### IAM Permissions
+
+To get started with BRClient, you must create an IAM user and generate Access Key/Secret Key. You have two options:
+
+* Option 1: Use the Managed Policy (Quick Setup)
+  - Go to Identity and Access Management (IAM) -> Users -> Create User
+  - Set permissions -> Select "Attach policies directly"
+  - Choose `AmazonBedrockFullAccess`
+  - Click Next -> Create User
+
+* Option 2: Set Least-Privilege Permissions
+  - When setting permissions with IAM policies, grant only the permissions required to perform a task. This is known as least-privilege permissions. Here's an example of least-privilege IAM Permissions for BRClient:
+    ```json
+    {
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "LeastPrivilege4BRClient",
-            "Effect": "Allow",
-            "Action": [
-                "bedrock:InvokeModel",
-                "bedrock:InvokeModelWithResponseStream"
-            ],
-            "Resource": "arn:aws:bedrock:*::foundation-model/anthropic.claude-3*"
+        "Sid": "LeastPrivilege4BRClient",
+        "Effect": "Allow",
+        "Action": [
+            "bedrock:InvokeModel",
+            "bedrock:InvokeModelWithResponseStream"
+        ],
+        "Resource": "arn:aws:bedrock:*::foundation-model/*"
         }
     ]
-}
-```
+    }
+    ```
+
+For more details about Amazon Bedrock identity-based policy, please visit [Link](https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html)
 
 ## Donation
 If you like this project, buy original author yidadaa a Coffee

--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ As the project is still in rapid itelating, we would like to suggest developers 
 5. run `yarn app:dev` to start a desktop app in developer mode.    or:   run `yarn dev` to start a local server and then access the app with browser.
 6. Optional, if you want to run it as an app, run `yarn app:build` to build it, and the find the target file (we believe you can, :-)
 
+### Least-privilege IAM Permission
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "LeastPrivilege4BRClient",
+            "Effect": "Allow",
+            "Action": [
+                "bedrock:InvokeModel",
+                "bedrock:InvokeModelWithResponseStream"
+            ],
+            "Resource": "arn:aws:bedrock:*::foundation-model/anthropic.claude-3*"
+        }
+    ]
+}
+```
 
 ## Donation
 If you like this project, buy original author yidadaa a Coffee

--- a/README_CN.md
+++ b/README_CN.md
@@ -48,6 +48,37 @@ https://github.com/DamonDeng/BRClient/releases/download/beta1/brclient_x86_mac.z
 5. 运行 `yarn app:dev`命令启动应用，或者:   运行 `yarn dev` 启动浏览器模式，通过localhost:3000访问
 6. （可选），如果你想构建自己的单独应用，可以运行 `yarn app:build`执行打包命令，然后去找一下打包出来的程序，都是开发者了，相信你可以找到。
 
+#### IAM 权限
+
+要开始使用 BRClient,您必须创建一个 IAM 用户并生成 Access Key/Secret Key。您有两个选择:
+
+* 选项 1:使用托管策略(快速设置)
+  - 转到身份和访问管理(IAM) -> 用户 -> 创建用户
+  - 设置权限 -> 选择"直接附加策略"
+  - 选择 `AmazonBedrockFullAccess`
+  - 单击下一步 -> 创建用户
+
+* 选项 2:设置最小权限
+  - 在使用 IAM 策略设置权限时,只授予执行任务所需的权限, 这称为最小权限。以下是 BRClient 最小 IAM 权限的示例:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "LeastPrivilege4BRClient",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ],
+      "Resource": "arn:aws:bedrock:*::foundation-model/*"
+    }
+  ]
+}
+```
+
+有关 Amazon Bedrock 基于身份的策略的更多详细信息,请访问[链接](https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html)。
 
 ## 支持一下
 如果你喜欢这个项目，大概率是因为你喜欢这个界面，那给项目的原作者yidadaa买杯咖啡吧


### PR DESCRIPTION
This pull request adds an "IAM Permissions" section to the README file, providing guidance on setting up the necessary IAM user and permissions for using BRClient.

The section covers two approaches:

1. Using the managed policy `AmazonBedrockFullAccess` for quick setup:
   - Instructions on creating an IAM user and attaching the `AmazonBedrockFullAccess` policy directly are provided.

2. Setting least-privilege permissions:
   - An explanation of the principle of least-privilege permissions is included.
   - An example IAM policy with least-privilege permissions specifically for BRClient is provided. The policy grants the necessary `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream` actions on the required resources.

By adding this section to the README, users will have clear guidance on setting up the appropriate IAM permissions to get started with BRClient, either using the convenient managed policy or following the best practice of least-privilege permissions.

Please review the changes and provide any feedback or suggestions for improvement.